### PR TITLE
Fixing "undefined operation random(10) times 0.1"

### DIFF
--- a/sass/_mixins.scss
+++ b/sass/_mixins.scss
@@ -108,14 +108,14 @@ $prefix-spec: true;
         #{$step} {
           @include vendorize(transform, translate(0px, 0px) rotate(0deg), webkit ms spec);
           @if($opacity){
-            opacity: random(10)*.1;
+            opacity: random(10) / 10;
           }
         }  
       } @else {
         #{$step} {
           @include vendorize(transform, translate($h, $v) rotate($r), webkit ms spec);
           @if($opacity){
-            opacity: random(10)*.1; 
+            opacity: random(10) / 10; 
           }
         }
       }


### PR DESCRIPTION
`sass --pre` on Windows machines throws an exception when compiling CSS shake like so.

```
Syntax error: Undefined operation: "random(10) times 0.1".
    on line 111 of .../vendor/csshake/sass/_mixins.scss, in `@content'
    from line 65 of .../vendor/csshake/sass/_mixins.scss, in `keyframes'
    from line 95 of .../vendor/csshake/sass/_mixins.scss, in `shake'
    from line 80 of .../vendor/csshake/sass/_shake.scss
    from line 2 of .../vendor/csshake/sass/csshake.scss
    from line 37 of app/styles/app.scss
```

This change, simple enough and equivalent, does not fail.
