### PR TITLE
Add missing rel="stylesheet" to link examples

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,9 +210,9 @@
 		
 			<h1 class="u-mt4">How to use</h1>
 				<h4>Include the css file then apply classes to elements</h4>
-				<pre class="language-markup"><code>&lt;link type=&quot;text/css&quot; href=&quot;csshake.min.css&quot;&gt;
+				<pre class="language-markup"><code>&lt;link rel=&quot;stylesheet&quot; type=&quot;text/css&quot; href=&quot;csshake.min.css&quot;&gt;
 &lt;!-- or from surge.sh --&gt;
-&lt;link type=&quot;text/css&quot; href=&quot;http://csshake.surge.sh/csshake.min.css&quot;&gt;</code></pre><br>
+&lt;link rel=&quot;stylesheet&quot; type=&quot;text/css&quot; href=&quot;http://csshake.surge.sh/csshake.min.css&quot;&gt;</code></pre><br>
 				<pre class="language-markup shake"><code>&lt;div class=&quot;shake&quot;&gt;&lt;/div&gt;</code></pre>
 				<pre class="language-markup shake-hard"><code>&lt;div class=&quot;shake-hard&quot;&gt;&lt;/div&gt;</code></pre>
 				<pre class="language-markup shake-slow"><code>&lt;div class=&quot;shake-slow&quot;&gt;&lt;/div&gt;</code></pre>
@@ -234,9 +234,9 @@
  <code class="shake">&lt;li class=&quot;shake&quot;&gt;&lt;/li&gt;</code>
 <code>&lt;/ul&gt;</code></pre>			
 				<pre class="language-markup"><code>&lt;!-- To include only some csshake animations use this syntax --&gt;
-&lt;link type=&quot;text/css&quot; href=&quot;csshake-slow.min.css&quot;&gt;
+&lt;link rel=&quot;stylesheet&quot; type=&quot;text/css&quot; href=&quot;csshake-slow.min.css&quot;&gt;
 &lt;!-- or from surge.sh --&gt;
-&lt;link type=&quot;text/css&quot; href=&quot;http://csshake.surge.sh/csshake-slow.min.css&quot;&gt;</code></pre><br>
+&lt;link rel=&quot;stylesheet&quot; type=&quot;text/css&quot; href=&quot;http://csshake.surge.sh/csshake-slow.min.css&quot;&gt;</code></pre><br>
 			<div class="arrow shake-vertical-slow shake-constant"></div>
 		</section>
 


### PR DESCRIPTION
If you try and copy from the example verbatim it will not work because of the missing rel="stylesheet" - added it :)