### PR TITLE
Fixed wrong interpretation of short animation rule by MS Edge

### DIFF
--- a/scss/_tools.scss
+++ b/scss/_tools.scss
@@ -82,7 +82,10 @@ $trigger: 'shake-trigger' !default;
   &.#{$prefix}-freeze,
   &.#{$prefix}-constant {
     @if $delay { animation-delay: $delay; }
-    animation: #{$name} $dur $t $q;
+    animation-name: #{$name};
+    animation-duration: $dur;
+    animation-timing-function: $t;
+    animation-iteration-count: $q;
   }
 
   &:hover,


### PR DESCRIPTION
Hi!

I noticed that animations go haywire in MS Edge, and after chasing down the cause, it turns out it is not interpreting the abbreviated version of the rule like other browsers do. So I made this small change that fixes it.